### PR TITLE
[BUG] Consider email starting by backtick correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var tester = /^[-!#$%&'*+\/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
+var tester = /^[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
 // Thanks to:
 // http://fightingforalostcause.net/misc/2006/compare-email-regex.php
 // http://thedailywtf.com/Articles/Validating_Email_Addresses.aspx

--- a/test.js
+++ b/test.js
@@ -25,7 +25,8 @@ const validSupported =
 	"local@sub.domains.com",
 	"backticks`are`legit@test.com",
 	"digit-only-domain@123.com",
-	"digit-only-domain-with-subdomain@sub.123.com"
+	"digit-only-domain-with-subdomain@sub.123.com",
+	"`a@a.fr"
 ];
 
 const validUnsupported =


### PR DESCRIPTION
Email addresses starting with a backtick character were not considered as valid ones.

The bug was detected thanks to [fast-check](https://github.com/dubzzz/fast-check/), a property based testing framework for JavaScript:
```js
const fc = require('fast-check');
const validator = require("email-validator");
fc.assert(
  fc.property(
    fc.emailAddress(),
    e => validator.validate(e)
  )
);
```