### PR TITLE
Regex test early on, remove redundant check

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ var tester = /^[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~
 exports.validate = function (email) {
   if (!email) return false;
 
-  var emailParts = email.split('@');
+  if (!tester.test(email)) return false;
 
-  if (emailParts.length !== 2) return false;
+  var emailParts = email.split('@');
 
   var account = emailParts[0];
   var address = emailParts[1];
@@ -27,7 +27,7 @@ exports.validate = function (email) {
     return part.length > 63;
   })) return false;
 
-  return tester.test(email);
+  return true;
 };
 
 exports.tester = tester;


### PR DESCRIPTION
Hi! I noticed that the regex already enforces that there should only be an `@` between two lumps of text, so an early check with the regex will:
- Save a redundant check
- Speed up the process by saving the following checks